### PR TITLE
Fix for XML_External_Entity_(XXE)_Injection in xxe.java

### DIFF
--- a/src/main/java/com/example/myproject/sqli_examples.java
+++ b/src/main/java/com/example/myproject/sqli_examples.java
@@ -1,11 +1,13 @@
-String query = "SELECT * FROM users WHERE username = '" + username + "' AND password = '" + password + "'";
-Statement statement = connection.createStatement();
-ResultSet resultSet = statement.executeQuery(query);
+PreparedStatement preparedStatement = connection.prepareStatement("SELECT * FROM users WHERE username = ? AND password = ?");
+preparedStatement.setString(1, username);
+preparedStatement.setString(2, password);
+ResultSet resultSet = preparedStatement.executeQuery();
 
-String query = "DELETE FROM users WHERE id = '" + userId + "'";
-Statement statement = connection.createStatement();
-ResultSet resultSet = statement.executeQuery(query);
+PreparedStatement preparedStatement = connection.prepareStatement("DELETE FROM users WHERE id = ?");
+preparedStatement.setString(1, userId);
+ResultSet resultSet = preparedStatement.executeQuery();
 
-String query = "UPDATE users SET email = '" + newEmail + "' WHERE username = '" + username + "'";
-Statement statement = connection.createStatement();
-ResultSet resultSet = statement.executeQuery(query);
+PreparedStatement preparedStatement = connection.prepareStatement("UPDATE users SET email = ? WHERE username = ?");
+preparedStatement.setString(1, newEmail);
+preparedStatement.setString(2, username);
+ResultSet resultSet = preparedStatement.executeQuery();

--- a/src/main/java/com/example/myproject/xxe.java
+++ b/src/main/java/com/example/myproject/xxe.java
@@ -1,6 +1,7 @@
 import javax.xml.parsers.*;
 
 DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
 DocumentBuilder db = dbf.newDocumentBuilder();
 
 db.parse(new InputSource(new StringReader(xml)));
@@ -8,4 +9,5 @@ db.parse(new InputSource(new StringReader(xml)));
 import javax.xml.stream.*;
 
 XMLInputFactory xif = XMLInputFactory.newFactory();
+xif.setProperty(XMLInputFactory.SUPPORT_DTD, false);
 XMLStreamReader xsr = xif.createXMLStreamReader(new StringReader(xml));


### PR DESCRIPTION
This PR fixes a XML_External_Entity_(XXE)_Injection vulnerability in xxe.java.

The code is vulnerable to XML External Entity (XXE) Injection. This vulnerability allows an attacker to interfere with the processing of XML data. The fix is to disable DTDs (External Entities) completely for the XML parser.