### PR TITLE
Security Fix for local-repo-src-main-java-com-example-myproject-sqli_examples.java

### DIFF
--- a/src/main/java/com/example/myproject/cmdi.java
+++ b/src/main/java/com/example/myproject/cmdi.java
@@ -4,6 +4,10 @@ public class CommandInjection {
 
     public static void directRuntimeExec(String userInput) throws IOException {
         Runtime runtime = Runtime.getRuntime();
-        runtime.exec("ping " + userInput);
+        if (userInput != null && userInput.matches("^[a-zA-Z0-9]*$") {
+    runtime.exec("ping " + userInput);
+} else {
+    throw new IllegalArgumentException("Invalid input");
+}
     }
 }

--- a/src/main/java/com/example/myproject/sqli_examples.java
+++ b/src/main/java/com/example/myproject/sqli_examples.java
@@ -1,11 +1,13 @@
-String query = "SELECT * FROM users WHERE username = '" + username + "' AND password = '" + password + "'";
-Statement statement = connection.createStatement();
-ResultSet resultSet = statement.executeQuery(query);
+PreparedStatement pstmt = connection.prepareStatement("SELECT * FROM users WHERE username = ? AND password = ?");
+pstmt.setString(1, username);
+pstmt.setString(2, password);
+ResultSet resultSet = pstmt.executeQuery();
 
-String query = "DELETE FROM users WHERE id = '" + userId + "'";
-Statement statement = connection.createStatement();
-ResultSet resultSet = statement.executeQuery(query);
+PreparedStatement pstmt = connection.prepareStatement("DELETE FROM users WHERE id = ?");
+pstmt.setString(1, userId);
+ResultSet resultSet = pstmt.executeQuery();
 
-String query = "UPDATE users SET email = '" + newEmail + "' WHERE username = '" + username + "'";
-Statement statement = connection.createStatement();
-ResultSet resultSet = statement.executeQuery(query);
+PreparedStatement pstmt = connection.prepareStatement("UPDATE users SET email = ? WHERE username = ?");
+pstmt.setString(1, newEmail);
+pstmt.setString(2, username);
+ResultSet resultSet = pstmt.executeQuery();


### PR DESCRIPTION
The original code is vulnerable to SQL Injection attacks. This is because it concatenates user-provided strings directly into the SQL query. An attacker could manipulate these strings to alter the query's logic, potentially gaining unauthorized access to data or performing other malicious actions. The fix is to use Prepared Statements, which can safely parameterize user-provided input, preventing SQL Injection attacks.