### PR TITLE
Security Fix for local-repo-src-main-java-com-example-myproject-xxe.java

### DIFF
--- a/src/main/java/com/example/myproject/xxe.java
+++ b/src/main/java/com/example/myproject/xxe.java
@@ -1,6 +1,7 @@
 import javax.xml.parsers.*;
 
 DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
 DocumentBuilder db = dbf.newDocumentBuilder();
 
 db.parse(new InputSource(new StringReader(xml)));
@@ -8,4 +9,5 @@ db.parse(new InputSource(new StringReader(xml)));
 import javax.xml.stream.*;
 
 XMLInputFactory xif = XMLInputFactory.newFactory();
+xif.setProperty(XMLInputFactory.SUPPORT_DTD, false);
 XMLStreamReader xsr = xif.createXMLStreamReader(new StringReader(xml));


### PR DESCRIPTION
The code is vulnerable to XML External Entity (XXE) Injection. This vulnerability allows an attacker to interfere with the processing of XML data. The fix is to disable DTDs (External Entities) completely.