### PR TITLE
Security Fix for local-repo-src-main-java-com-example-myproject-sqli_examples.java

### DIFF
--- a/src/main/java/com/example/myproject/cmdi.java
+++ b/src/main/java/com/example/myproject/cmdi.java
@@ -4,6 +4,10 @@ public class CommandInjection {
 
     public static void directRuntimeExec(String userInput) throws IOException {
         Runtime runtime = Runtime.getRuntime();
-        runtime.exec("ping " + userInput);
+        if (userInput != null && userInput.matches("^[a-zA-Z0-9]*$") {
+    runtime.exec("ping " + userInput);
+} else {
+    throw new IllegalArgumentException("Invalid input");
+}
     }
 }

--- a/src/main/java/com/example/myproject/sqli_examples.java
+++ b/src/main/java/com/example/myproject/sqli_examples.java
@@ -1,11 +1,13 @@
-String query = "SELECT * FROM users WHERE username = '" + username + "' AND password = '" + password + "'";
-Statement statement = connection.createStatement();
-ResultSet resultSet = statement.executeQuery(query);
+PreparedStatement statement = connection.prepareStatement("SELECT * FROM users WHERE username = ? AND password = ?");
+statement.setString(1, username);
+statement.setString(2, password);
+ResultSet resultSet = statement.executeQuery();
 
-String query = "DELETE FROM users WHERE id = '" + userId + "'";
-Statement statement = connection.createStatement();
-ResultSet resultSet = statement.executeQuery(query);
+PreparedStatement statement = connection.prepareStatement("DELETE FROM users WHERE id = ?");
+statement.setString(1, userId);
+resultSet = statement.executeQuery();
 
-String query = "UPDATE users SET email = '" + newEmail + "' WHERE username = '" + username + "'";
-Statement statement = connection.createStatement();
-ResultSet resultSet = statement.executeQuery(query);
+PreparedStatement statement = connection.prepareStatement("UPDATE users SET email = ? WHERE username = ?");
+statement.setString(1, newEmail);
+statement.setString(2, username);
+resultSet = statement.executeQuery();


### PR DESCRIPTION
The original code is vulnerable to SQL Injection attacks. This is because it concatenates user input directly into the SQL query. An attacker could manipulate the input to alter the query, leading to unauthorized data access, data corruption, or data loss. The fix is to use Prepared Statements, which can prevent SQL Injection attacks by separating SQL logic from data.