### PR TITLE
Security Fix for local-repo-src-main-java-com-example-myproject-cmdi.java

### DIFF
--- a/src/main/java/com/example/myproject/cmdi.java
+++ b/src/main/java/com/example/myproject/cmdi.java
@@ -4,6 +4,10 @@ public class CommandInjection {
 
     public static void directRuntimeExec(String userInput) throws IOException {
         Runtime runtime = Runtime.getRuntime();
-        runtime.exec("ping " + userInput);
+        if (userInput != null && userInput.matches("^[a-zA-Z0-9]*$") {
+    runtime.exec("ping " + userInput);
+} else {
+    throw new IllegalArgumentException("Invalid input");
+}
     }
 }


### PR DESCRIPTION
The code is vulnerable to command injection as it directly uses user input in a system command. The fix is to validate the user input before using it in the command. In the fix, we are checking if the user input only contains alphanumeric characters. If it does, we execute the command, otherwise, we throw an exception.