### PR TITLE
Security Fix for sqli_examples.java

### DIFF
--- a/src/main/java/com/example/myproject/sqli_examples.java
+++ b/src/main/java/com/example/myproject/sqli_examples.java
@@ -1,11 +1,13 @@
-String query = "SELECT * FROM users WHERE username = '" + username + "' AND password = '" + password + "'";
-Statement statement = connection.createStatement();
-ResultSet resultSet = statement.executeQuery(query);
+PreparedStatement statement = connection.prepareStatement("SELECT * FROM users WHERE username = ? AND password = ?");
+statement.setString(1, username);
+statement.setString(2, password);
+ResultSet resultSet = statement.executeQuery();
 
-String query = "DELETE FROM users WHERE id = '" + userId + "'";
-Statement statement = connection.createStatement();
-ResultSet resultSet = statement.executeQuery(query);
+PreparedStatement statement = connection.prepareStatement("DELETE FROM users WHERE id = ?");
+statement.setString(1, userId);
+ResultSet resultSet = statement.executeQuery();
 
-String query = "UPDATE users SET email = '" + newEmail + "' WHERE username = '" + username + "'";
-Statement statement = connection.createStatement();
-ResultSet resultSet = statement.executeQuery(query);
+PreparedStatement statement = connection.prepareStatement("UPDATE users SET email = ? WHERE username = ?");
+statement.setString(1, newEmail);
+statement.setString(2, username);
+ResultSet resultSet = statement.executeQuery();


### PR DESCRIPTION
The original code is vulnerable to SQL Injection attacks. This is because it concatenates user-provided strings directly into the SQL query. An attacker could manipulate these strings to alter the query's logic, potentially gaining unauthorized access to data or performing other malicious actions. The fix is to use PreparedStatements, which safely parameterize the query and prevent SQL Injection attacks.